### PR TITLE
Adds non-stacking implementation of Toaster

### DIFF
--- a/src/main/java/com/novoda/notils/logger/toast/Toaster.java
+++ b/src/main/java/com/novoda/notils/logger/toast/Toaster.java
@@ -100,6 +100,8 @@ public class Toaster {
         if (context != null) {
             toast = Toast.makeText(context, msgId, length);
             toast.show();
+        } else {
+            Log.e("Unable to toast message (context is null).");
         }
     }
 


### PR DESCRIPTION
Cancels previous toast before showing new toast so that you don't build up a queue of toasts.

I added a new class to do this rather than modify the existing toaster; can do so if it's preferred as the saner behaviour given that toasts aren't attached to a particular screen (it could take a while to get through all messages, and by that time, the user might be on a completely different screen/app).
