### PR TITLE
improved logs adding vaargs and custom separators

### DIFF
--- a/src/main/java/com/novoda/notils/logger/simple/Log.java
+++ b/src/main/java/com/novoda/notils/logger/simple/Log.java
@@ -120,7 +120,9 @@ public final class Log {
         }
     }
 
-    @Deprecated
+    /**
+     * @deprecated use (Throwable t, Object... msg) or (Throwable t, String separator, Object... msg) instead
+     */
     public static void d(String msg, Throwable t) {
         d(t, msg);
     }
@@ -139,7 +141,9 @@ public final class Log {
         }
     }
 
-    @Deprecated
+    /**
+     * @deprecated use (Throwable t, Object... msg) or (Throwable t, String separator, Object... msg) instead
+     */
     public static void e(String msg, Throwable t) {
         e(t, msg);
     }
@@ -157,7 +161,9 @@ public final class Log {
         }
     }
 
-    @Deprecated
+    /**
+     * @deprecated use (Throwable t, Object... msg) or (Throwable t, String separator, Object... msg) instead
+     */
     public static void wtf(String msg, Throwable t) {
         wtf(t, msg);
     }


### PR DESCRIPTION
Adds varargs for the logs, allowing the user to pass a list of Objects to be logged (using their toString() methods).

This doesn't break the API [after fix applied] but makes it less awkward to use in some situations

i.e Log.d("blabla", "blabla2", 3242342, myObject)
