### PR TITLE
fixed the separator taken as a vaarg

### DIFF
--- a/src/main/java/com/novoda/notils/logger/simple/Log.java
+++ b/src/main/java/com/novoda/notils/logger/simple/Log.java
@@ -24,21 +24,21 @@ public final class Log {
     private static final int DOT_CLASS = 5;
 
     /**
-     * Default separator for the concatenation of the vaargs
+     * Separator for the concatenation of the vaargs
      */
-    private static final String DEFAULT_SEPARATOR = " ";
+    private static String SEPARATOR = " ";
 
     private Log() {
     }
 
-    public static void v(Object... msg) {
-        v(DEFAULT_SEPARATOR, msg);
+    public static void setSeparator(String sep) {
+        SEPARATOR = sep;
     }
 
-    public static void v(String separator, Object... msg) {
+    public static void v(Object... msg) {
         try {
             if (SHOW_LOGS) {
-                android.util.Log.v(TAG, getDetailedLog(formatString(separator, msg)));
+                android.util.Log.v(TAG, getDetailedLog(formatString(msg)));
             }
         } catch (RuntimeException ignore) {
             logError(ignore);
@@ -46,13 +46,9 @@ public final class Log {
     }
 
     public static void i(Object... msg) {
-        i(DEFAULT_SEPARATOR, msg);
-    }
-
-    public static void i(String separator, Object... msg) {
         try {
             if (SHOW_LOGS) {
-                android.util.Log.i(TAG, getDetailedLog(formatString(separator, msg)));
+                android.util.Log.i(TAG, getDetailedLog(formatString(msg)));
             }
         } catch (RuntimeException ignore) {
             logError(ignore);
@@ -60,13 +56,9 @@ public final class Log {
     }
 
     public static void d(Object... msg) {
-        d(DEFAULT_SEPARATOR, msg);
-    }
-
-    public static void d(String separator, Object... msg) {
         try {
             if (SHOW_LOGS) {
-                android.util.Log.d(TAG, getDetailedLog(formatString(separator, msg)));
+                android.util.Log.d(TAG, getDetailedLog(formatString(msg)));
             }
         } catch (RuntimeException ignore) {
             logError(ignore);
@@ -74,13 +66,9 @@ public final class Log {
     }
 
     public static void w(Object... msg) {
-        w(DEFAULT_SEPARATOR, msg);
-    }
-
-    public static void w(String separator, Object... msg) {
         try {
             if (SHOW_LOGS) {
-                android.util.Log.w(TAG, getDetailedLog(formatString(separator, msg)));
+                android.util.Log.w(TAG, getDetailedLog(formatString(msg)));
             }
         } catch (RuntimeException ignore) {
             logError(ignore);
@@ -88,13 +76,9 @@ public final class Log {
     }
 
     public static void e(Object... msg) {
-        e(DEFAULT_SEPARATOR, msg);
-    }
-
-    public static void e(String separator, Object... msg) {
         try {
             if (SHOW_LOGS) {
-                android.util.Log.e(TAG, getDetailedLog(formatString(separator, msg)));
+                android.util.Log.e(TAG, getDetailedLog(formatString(msg)));
             }
         } catch (RuntimeException ignore) {
             logError(ignore);
@@ -102,79 +86,71 @@ public final class Log {
     }
 
     @Deprecated
+    /**
+     * @deprecated use (Throwable t, Object... msg) 
+     */
     public static void w(String msg, Throwable t) {
         w(t,msg);
     }
 
     public static void w(Throwable t, Object... msg) {
-        w(t, DEFAULT_SEPARATOR, msg);
-    }
-
-    public static void w(Throwable t, String separator, Object... msg) {
         try {
             if (SHOW_LOGS) {
-                android.util.Log.w(TAG, getDetailedLog(formatString(separator, msg)), t);
+                android.util.Log.w(TAG, getDetailedLog(formatString(msg)), t);
             }
         } catch (RuntimeException ignore) {
             logError(ignore);
         }
     }
 
+    @Deprecated
     /**
-     * @deprecated use (Throwable t, Object... msg) or (Throwable t, String separator, Object... msg) instead
+     * @deprecated use (Throwable t, Object... msg)
      */
     public static void d(String msg, Throwable t) {
         d(t, msg);
     }
 
     public static void d(Throwable t, Object... msg) {
-        d(t, DEFAULT_SEPARATOR, msg);
-    }
-
-    public static void d(Throwable t, String separator, Object... msg) {
         try {
             if (SHOW_LOGS) {
-                android.util.Log.d(TAG, getDetailedLog(formatString(separator, msg)), t);
+                android.util.Log.d(TAG, getDetailedLog(formatString(msg)), t);
             }
         } catch (RuntimeException ignore) {
             logError(ignore);
         }
     }
 
+    @Deprecated
     /**
-     * @deprecated use (Throwable t, Object... msg) or (Throwable t, String separator, Object... msg) instead
+     * @deprecated use (Throwable t, Object... msg) 
      */
     public static void e(String msg, Throwable t) {
         e(t, msg);
     }
-    public static void e(Throwable t, Object... msg) {
-        e(t, DEFAULT_SEPARATOR, msg);
-    }
 
-    public static void e(Throwable t, String separator, Object... msg) {
+    public static void e(Throwable t, Object... msg) {
         try {
             if (SHOW_LOGS) {
-                android.util.Log.e(TAG, getDetailedLog(formatString(separator, msg)), t);
+                android.util.Log.e(TAG, getDetailedLog(formatString(msg)), t);
             }
         } catch (RuntimeException ignore) {
             logError(ignore);
         }
     }
 
+    @Deprecated
     /**
-     * @deprecated use (Throwable t, Object... msg) or (Throwable t, String separator, Object... msg) instead
+     * @deprecated use (Throwable t, Object... msg)
      */
     public static void wtf(String msg, Throwable t) {
         wtf(t, msg);
     }
-    public static void wtf(Throwable t, Object... msg) {
-        wtf(t, DEFAULT_SEPARATOR, msg);
-    }
 
-    public static void wtf(Throwable t, String separator, Object... msg) {
+    public static void wtf(Throwable t, Object... msg) {
         try {
             if (SHOW_LOGS) {
-                android.util.Log.wtf(TAG, getDetailedLog(formatString(separator, msg)), t);
+                android.util.Log.wtf(TAG, getDetailedLog(formatString(msg)), t);
             }
         } catch (RuntimeException ignore) {
             logError(ignore);
@@ -200,10 +176,10 @@ public final class Log {
         android.util.Log.e(TAG, "Error", ignore);
     }
 
-    private static String formatString(String sep, Object... msg) {
+    private static String formatString(Object... msg) {
         StringBuilder stringBuilder = new StringBuilder();
         for (Object o : msg) {
-            stringBuilder.append(String.valueOf(o)).append(sep);
+            stringBuilder.append(String.valueOf(o)).append(SEPARATOR);
         }
         return stringBuilder.toString();
     }


### PR DESCRIPTION
fixed the separator taken as a vaarg problem so now : 
`Log.i("Response data is", responseData, "and code is", responseHttpCode);`

_WILL_ log this : 
`"Response data is [value of responseData] and code is [value of responseHttpCode]"`
