### PR TITLE
Provide getter/setter for NoTils/simple.Log.SHOW_LOGS switch

### DIFF
--- a/src/main/java/com/novoda/notils/logger/simple/Log.java
+++ b/src/main/java/com/novoda/notils/logger/simple/Log.java
@@ -90,10 +90,11 @@ public final class Log {
         }
     }
 
-    @Deprecated
+
     /**
-     * @deprecated use (Throwable t, Object... msg) 
+     * @deprecated use (Throwable t, Object... msg)
      */
+    @Deprecated
     public static void w(String msg, Throwable t) {
         w(t, msg);
     }
@@ -108,10 +109,10 @@ public final class Log {
         }
     }
 
-    @Deprecated
     /**
      * @deprecated use (Throwable t, Object... msg)
      */
+    @Deprecated
     public static void d(String msg, Throwable t) {
         d(t, msg);
     }
@@ -126,10 +127,11 @@ public final class Log {
         }
     }
 
-    @Deprecated
+
     /**
      * @deprecated use (Throwable t, Object... msg) 
      */
+    @Deprecated
     public static void e(String msg, Throwable t) {
         e(t, msg);
     }
@@ -144,10 +146,10 @@ public final class Log {
         }
     }
 
-    @Deprecated
     /**
      * @deprecated use (Throwable t, Object... msg)
      */
+    @Deprecated
     public static void wtf(String msg, Throwable t) {
         wtf(t, msg);
     }


### PR DESCRIPTION
This is mainly to get a way to avoid the findbugs warning:

```
Write to static field com.novoda.notils.logger.simple.Log.SHOW_LOGS from instance method xyz
```

Eventually this public static field should be demoted to private (breaking all projects in the process). Adding a deprecated flag for now to push people to migrate to the new accessor methods.
