### PR TITLE
Update StrictModeManager to allow custom rule violations

### DIFF
--- a/src/main/java/com/novoda/notils/logger/analyse/StrictModeManager.java
+++ b/src/main/java/com/novoda/notils/logger/analyse/StrictModeManager.java
@@ -1,5 +1,6 @@
 package com.novoda.notils.logger.analyse;
 
+import android.os.Build;
 import android.os.StrictMode;
 
 /**
@@ -58,9 +59,11 @@ public final class StrictModeManager {
     }
 
     private static StrictMode.VmPolicy.Builder newVmPolicyBuilderWithDefaultViolations() {
-        return new StrictMode.VmPolicy.Builder()
-                .detectLeakedSqlLiteObjects()
-                .detectLeakedRegistrationObjects();
+        StrictMode.VmPolicy.Builder builder = new StrictMode.VmPolicy.Builder().detectLeakedSqlLiteObjects();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            builder.detectLeakedRegistrationObjects();
+        }
+        return builder;
     }
 
     private static StrictMode.ThreadPolicy.Builder newThreadPolicyBuilderWithDefaultViolations() {


### PR DESCRIPTION
Allows specification of what is considered a violation - this is to avoid the annoying death on activity rotate bug.

At the same time, I update the default violation rules to avoid the activity instances count - this means that it won't catch leaked activities anymore, but that rule was buggy anyway (false positives, e.g. on activity rotates, in a fresh clean project) which led to people turning strict mode off.

![selfie-0](http://i.imgur.com/LQT68sW.gif)
