### PR TITLE
Add format()'ting ctor to DeveloperError

### DIFF
--- a/src/main/java/com/novoda/notils/exception/DeveloperError.java
+++ b/src/main/java/com/novoda/notils/exception/DeveloperError.java
@@ -12,7 +12,12 @@ public class DeveloperError extends RuntimeException {
         super(detailMessage);
     }
 
+    public DeveloperError(String messageTemplate, String... args) {
+        super(String.format(messageTemplate, args));
+    }
+
     public DeveloperError(String detailMessage, Throwable throwable) {
         super(detailMessage, throwable);
     }
+
 }

--- a/src/main/java/com/novoda/notils/exception/DeveloperError.java
+++ b/src/main/java/com/novoda/notils/exception/DeveloperError.java
@@ -12,7 +12,7 @@ public class DeveloperError extends RuntimeException {
         super(detailMessage);
     }
 
-    public DeveloperError(String messageTemplate, String... args) {
+    public DeveloperError(String messageTemplate, Object... args) {
         super(String.format(messageTemplate, args));
     }
 


### PR DESCRIPTION
I've noticed that we end up using a lot something like this in our code:

```java
throw new DeveloperError(String.format("Type %s not supported", myType.name()));
```

So this PR implements a simple ctor for `DeveloperError` to encapsulate it:

```java
throw new DeveloperError("Type %s not supported", myType.name());
```

I don't think the other ctor (that takes a `Throwable` as well) actually needs this treatment. That is primarily used to wrap other exceptions, while this one is useful for example for `default` labels in switch/cases where we don't handle (yet?) some enum values, and similar scenarios.

Here's a cute gif to drive my point further.

![dog-cute-playing](https://cloud.githubusercontent.com/assets/153802/6667861/bfb07522-cbe6-11e4-99ce-675dfc5a0a12.gif)
