### PR TITLE
Inherit from Error instead of RuntimeException.

### DIFF
--- a/src/main/java/com/novoda/notils/exception/DeveloperError.java
+++ b/src/main/java/com/novoda/notils/exception/DeveloperError.java
@@ -6,7 +6,7 @@ package com.novoda.notils.exception;
  * get feedback on the situation.
  * <b>You should never try catch a DeveloperError</b>
  */
-public class DeveloperError extends RuntimeException {
+public class DeveloperError extends Error {
 
     public DeveloperError(String detailMessage) {
         super(detailMessage);


### PR DESCRIPTION
According to the Java semantics of Exceptions:
>The class Exception and its subclasses are a form of Throwable that indicates conditions that a reasonable application might want to catch.

Instead, the semantics of Error are as following:
> An Error is a subclass of Throwable that indicates serious problems that a reasonable application should not try to catch. Most such errors are abnormal conditions.
