### PR TITLE
In Log messages (file_name:line_number) links to source code in Android Studio

### DIFF
--- a/src/main/java/com/novoda/notils/logger/simple/Log.java
+++ b/src/main/java/com/novoda/notils/logger/simple/Log.java
@@ -174,11 +174,12 @@ public final class Log {
         if (!shouldShowLogs()) {
             return msg;
         }
-        Thread current = Thread.currentThread();
-        final StackTraceElement trace = current.getStackTrace()[depth];
+        Thread currentThread = Thread.currentThread();
+        final StackTraceElement trace = currentThread.getStackTrace()[depth];
         final String filename = trace.getFileName();
-        return "[" + current.getName() + "][" + "(" + filename.substring(0, filename.length() - DOT_CLASS) + ".java:"
-                + trace.getLineNumber() + ")." + trace.getMethodName() + "] " + msg;
+        final String linkableSourcePosition = String.format("(%s.java:%d)", filename.substring(0, filename.length() - DOT_CLASS), trace.getLineNumber());
+        final String logPrefix = String.format("[%s][%s.%s] ", currentThread.getName(), linkableSourcePosition, trace.getMethodName());
+        return logPrefix + msg;
     }
 
     private static void logError(Throwable ignore) {

--- a/src/main/java/com/novoda/notils/logger/simple/Log.java
+++ b/src/main/java/com/novoda/notils/logger/simple/Log.java
@@ -177,8 +177,8 @@ public final class Log {
         Thread current = Thread.currentThread();
         final StackTraceElement trace = current.getStackTrace()[depth];
         final String filename = trace.getFileName();
-        return "[" + current.getName() + "][" + filename.substring(0, filename.length() - DOT_CLASS) + "."
-                + trace.getMethodName() + ":" + trace.getLineNumber() + "] " + msg;
+        return "[" + current.getName() + "][" + "(" + filename.substring(0, filename.length() - DOT_CLASS) + ".java:"
+                + trace.getLineNumber() + ")." + trace.getMethodName() + "] " + msg;
     }
 
     private static void logError(Throwable ignore) {


### PR DESCRIPTION
Change logging of class name and line number to filename and line number. This way Android Studio can link to the source code.

Before:
![before](https://cloud.githubusercontent.com/assets/246473/7754749/445a3646-ffef-11e4-80b1-6ec4588f9114.png)

After:
![after](https://cloud.githubusercontent.com/assets/246473/7754720/26029da0-ffef-11e4-97d8-4cf40936222f.png)
