### PR TITLE
ContentResolver Query utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ notils contains a set of common classes that we use in our projects:
   - `SimpleDateFormatThreadSafe` allowing you to use date formatting from multiple threads
   - `DeveloperError` - custom exceptions for explicit declaration / faster feedback when something goes wrong
   - `SimpleTextWatcher` - simple implementation of `android.text.TextWatcher` with stub implementations of each method
+  - `QueryUtils` - easily create placeholders for ContentResolver operations selection
 
 
 ## Adding to your project

--- a/src/main/java/com/novoda/notils/string/QueryUtils.java
+++ b/src/main/java/com/novoda/notils/string/QueryUtils.java
@@ -1,0 +1,23 @@
+package com.novoda.notils.string;
+
+import java.util.Arrays;
+
+public class QueryUtils {
+
+    /**
+     * Creates a string to be used as a placeholder in {@link android.content.ContentResolver} operations selection.
+     * This will allow to use more selection arguments and have them replaced.
+     *
+     * @param size The number of selection arguments
+     * @return Example: for size == 3 : "?, ?, ?"
+     */
+    public static String createQuerySelectionPlaceholdersOfSize(int size) {
+        String[] questionMarks = new String[size];
+        for (int i = 0; i < size; i++) {
+            questionMarks[i] = "?";
+        }
+
+        return StringUtils.join(Arrays.asList(questionMarks), ", ");
+    }
+
+}

--- a/src/main/java/com/novoda/notils/string/QueryUtils.java
+++ b/src/main/java/com/novoda/notils/string/QueryUtils.java
@@ -6,12 +6,12 @@ public class QueryUtils {
 
     /**
      * Creates a string to be used as a placeholder in {@link android.content.ContentResolver} operations selection.
-     * This will allow to use more selection arguments and have them replaced.
+     * This will allow to use more selection arguments and have them replaced when using the IN operator.
      *
      * @param size The number of selection arguments
      * @return Example: for size == 3 : "?, ?, ?"
      */
-    public static String createQuerySelectionPlaceholdersOfSize(int size) {
+    public static String createSelectionPlaceholdersOfSize(int size) {
         String[] questionMarks = new String[size];
         for (int i = 0; i < size; i++) {
             questionMarks[i] = "?";

--- a/src/main/java/com/novoda/notils/string/QueryUtils.java
+++ b/src/main/java/com/novoda/notils/string/QueryUtils.java
@@ -1,7 +1,5 @@
 package com.novoda.notils.string;
 
-import java.util.Arrays;
-
 public class QueryUtils {
 
     /**
@@ -12,12 +10,20 @@ public class QueryUtils {
      * @return Example: for size == 3 : "?, ?, ?"
      */
     public static String createSelectionPlaceholdersOfSize(int size) {
-        String[] questionMarks = new String[size];
-        for (int i = 0; i < size; i++) {
-            questionMarks[i] = "?";
+        if (size == 0) {
+            return "";
         }
 
-        return StringUtils.join(Arrays.asList(questionMarks), ", ");
+        int sizeOfResult = size * 3 - 2;
+        char[] result = new char[sizeOfResult];
+        for (int i = 0; i < sizeOfResult - 1; i += 3) {
+            result[i] = '?';
+            result[i + 1] = ',';
+            result[i + 2] = ' ';
+        }
+        result[sizeOfResult - 1] = '?';
+
+        return new String(result);
     }
 
 }

--- a/src/main/java/com/novoda/notils/string/StringUtils.java
+++ b/src/main/java/com/novoda/notils/string/StringUtils.java
@@ -52,4 +52,19 @@ public abstract class StringUtils {
             return string;
         }
     }
+
+    /**
+     * Create a String array from a generic Object array
+     *
+     * @param objects The array of objects to be converted to Strings
+     * @return An String array in which every element is the String representation of an element from the input array
+     */
+    public static String[] toStringArray(Object[] objects) {
+        int length = objects.length;
+        String[] stringArray = new String[length];
+        for (int i = 0; i < length; i++) {
+            stringArray[i] = String.valueOf(objects[i]);
+        }
+        return stringArray;
+    }
 }

--- a/src/test/java/com/novoda/notils/string/QueryUtilsTest.java
+++ b/src/test/java/com/novoda/notils/string/QueryUtilsTest.java
@@ -1,0 +1,31 @@
+package com.novoda.notils.string;
+
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class QueryUtilsTest {
+
+    @Test
+    public void testSizeOfZeroReturnsEmptyString() {
+
+        String expected = "";
+        assertEquals(expected, QueryUtils.createSelectionPlaceholdersOfSize(0));
+    }
+
+    @Test
+    public void testSizeOfOneReturnsJustQuestionMark() {
+
+        String expected = "?";
+        assertEquals(expected, QueryUtils.createSelectionPlaceholdersOfSize(1));
+    }
+
+    @Test
+    public void testSizeBiggerThanOneReturnsSameNumberOfQuestionMarkSeparatedByCommas() {
+
+        String expected = "?, ?, ?, ?, ?, ?, ?, ?, ?, ?";
+        assertEquals(expected, QueryUtils.createSelectionPlaceholdersOfSize(10));
+    }
+
+}


### PR DESCRIPTION
This PR adds a couple of methods useful for `ContentResolver` operations, when multiple selection arguments are needed.

`ContentResolver` operations can use `?` for placeholders to be replaced from the content of the operation `selectionArgs` parameter. Every selectionArg, however, requires a dedicated placeholders.

For example the following code won't work:
```
String[] selectionArgs = {"1, 2, 3"};
contentResolver.delete(uri, "_id IN (?)", selectionArgs);
```

while this will:
```
String[] selectionArgs = {"1, 2, 3"};
contentResolver.delete(uri, "_id IN (?, ?, ?)", selectionArgs);
```

The two added methods allows to easily create both the selection part (`?, ?, ... ?`) and the selectionArgs String array