### PR TITLE
Date format should use composition and not inheritance

### DIFF
--- a/src/main/java/com/novoda/notils/date/SimpleDateFormatThreadSafe.java
+++ b/src/main/java/com/novoda/notils/date/SimpleDateFormatThreadSafe.java
@@ -12,7 +12,7 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 
-public class SimpleDateFormatThreadSafe extends SimpleDateFormat {
+public class SimpleDateFormatThreadSafe {
 
     private final ThreadLocal<SimpleDateFormat> localSimpleDateFormat;
 
@@ -20,150 +20,120 @@ public class SimpleDateFormatThreadSafe extends SimpleDateFormat {
      * @see java.text.SimpleDateFormat#SimpleDateFormat(String, java.text.DateFormatSymbols)
      */
     public SimpleDateFormatThreadSafe(final String pattern, final DateFormatSymbols formatSymbols) {
-        super(pattern, formatSymbols);
-        localSimpleDateFormat = new ThreadLocal<SimpleDateFormat>() {
-            @Override
-            protected SimpleDateFormat initialValue() {
-                return new SimpleDateFormat(pattern, formatSymbols);
-            }
-        };
+        this(new SimpleDateFormat(pattern, formatSymbols));
     }
 
     /**
      * @see java.text.SimpleDateFormat#SimpleDateFormat(String, java.util.Locale)
      */
     public SimpleDateFormatThreadSafe(final String pattern, final Locale locale) {
-        super(pattern, locale);
-        localSimpleDateFormat = new ThreadLocal<SimpleDateFormat>() {
+        this(new SimpleDateFormat(pattern, locale));
+    }
+
+    private SimpleDateFormatThreadSafe(final SimpleDateFormat localSimpleDateFormat) {
+        this.localSimpleDateFormat = new ThreadLocal<SimpleDateFormat>() {
             @Override
             protected SimpleDateFormat initialValue() {
-                return new SimpleDateFormat(pattern, locale);
+                return localSimpleDateFormat;
             }
         };
     }
 
-    @Override
     public Object parseObject(String source) throws ParseException {
         return localSimpleDateFormat.get().parseObject(source);
     }
 
-    @Override
     public Date parse(String source) throws ParseException {
         return localSimpleDateFormat.get().parse(source);
     }
 
-    @Override
     public Object parseObject(String source, ParsePosition position) {
         return localSimpleDateFormat.get().parseObject(source, position);
     }
 
-    @Override
     public void setCalendar(Calendar newCalendar) {
         localSimpleDateFormat.get().setCalendar(newCalendar);
     }
 
-    @Override
     public Calendar getCalendar() {
         return localSimpleDateFormat.get().getCalendar();
     }
 
-    @Override
     public void setNumberFormat(NumberFormat newNumberFormat) {
         localSimpleDateFormat.get().setNumberFormat(newNumberFormat);
     }
 
-    @Override
     public NumberFormat getNumberFormat() {
         return localSimpleDateFormat.get().getNumberFormat();
     }
 
-    @Override
     public void setTimeZone(TimeZone zone) {
         localSimpleDateFormat.get().setTimeZone(zone);
     }
 
-    @Override
     public TimeZone getTimeZone() {
         return localSimpleDateFormat.get().getTimeZone();
     }
 
-    @Override
     public void setLenient(boolean lenient) {
         localSimpleDateFormat.get().setLenient(lenient);
     }
 
-    @Override
     public boolean isLenient() {
         return localSimpleDateFormat.get().isLenient();
     }
 
-    @Override
     public void set2DigitYearStart(Date startDate) {
         localSimpleDateFormat.get().set2DigitYearStart(startDate);
     }
 
-    @Override
     public Date get2DigitYearStart() {
         return localSimpleDateFormat.get().get2DigitYearStart();
     }
 
-    @Override
     public StringBuffer format(Date date, StringBuffer toAppendTo, FieldPosition position) {
         return localSimpleDateFormat.get().format(date, toAppendTo, position);
     }
 
-    @Override
     public AttributedCharacterIterator formatToCharacterIterator(Object object) {
         return localSimpleDateFormat.get().formatToCharacterIterator(object);
     }
 
-    @Override
     public Date parse(String text, ParsePosition position) {
         return localSimpleDateFormat.get().parse(text, position);
     }
 
-    @Override
     public String toPattern() {
         return localSimpleDateFormat.get().toPattern();
     }
 
-    @Override
     public String toLocalizedPattern() {
         return localSimpleDateFormat.get().toLocalizedPattern();
     }
 
-    @Override
     public void applyPattern(String pattern) {
         localSimpleDateFormat.get().applyPattern(pattern);
     }
 
-    @Override
     public void applyLocalizedPattern(String pattern) {
         localSimpleDateFormat.get().applyLocalizedPattern(pattern);
     }
 
-    @Override
     public DateFormatSymbols getDateFormatSymbols() {
         return localSimpleDateFormat.get().getDateFormatSymbols();
     }
 
-    @Override
     public void setDateFormatSymbols(DateFormatSymbols newFormatSymbols) {
         localSimpleDateFormat.get().setDateFormatSymbols(newFormatSymbols);
     }
 
-    @Override
-    public String toString() {
-        return localSimpleDateFormat.get().toString();
-    }
-
-    @SuppressWarnings("CloneDoesntCallSuperClone") // it calls our wrapped clone
+    @SuppressWarnings("CloneDoesntCallSuperClone") // Wrapper object should delegate even clone
     @Override
     public Object clone() {
-        return localSimpleDateFormat.get().clone();
+        return new SimpleDateFormatThreadSafe((SimpleDateFormat) localSimpleDateFormat.get().clone());
     }
 
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass") // it is done in the super
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass") // Wrapper object should delegate even equals
     @Override
     public boolean equals(Object object) {
         return localSimpleDateFormat.get().equals(object);
@@ -172,6 +142,11 @@ public class SimpleDateFormatThreadSafe extends SimpleDateFormat {
     @Override
     public int hashCode() {
         return localSimpleDateFormat.get().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return localSimpleDateFormat.get().toString();
     }
 
 }


### PR DESCRIPTION
The SimpleDateFormatThreadSafe should not extend SimpleDateFormat since it is using composition.