### PR TITLE
Fix toaster displayLong(int) use LENGTH_LONG

### DIFF
--- a/src/main/java/com/novoda/notils/logger/toast/NonStackingToastDisplayer.java
+++ b/src/main/java/com/novoda/notils/logger/toast/NonStackingToastDisplayer.java
@@ -57,7 +57,7 @@ public class NonStackingToastDisplayer implements ToastDisplayer {
      */
     @Override
     public void displayLong(int stringResourceId) {
-        display(stringResourceId, Toast.LENGTH_SHORT);
+        display(stringResourceId, Toast.LENGTH_LONG);
     }
 
     private void display(String message, int lengthMillis) {

--- a/src/main/java/com/novoda/notils/logger/toast/StackingToastDisplayer.java
+++ b/src/main/java/com/novoda/notils/logger/toast/StackingToastDisplayer.java
@@ -36,7 +36,7 @@ public class StackingToastDisplayer implements ToastDisplayer {
 
     @Override
     public void displayLong(int stringResourceId) {
-        display(stringResourceId, Toast.LENGTH_SHORT);
+        display(stringResourceId, Toast.LENGTH_LONG);
     }
 
     private void display(String message, int lengthMillis) {


### PR DESCRIPTION
I've noticed one of the two `Toaster#displayLong()` overloads uses `LENGTH_SHORT` in both implementations. This PR fixes the issue.