### PR TITLE
Programmatic locking of orientation only when not debugging

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     compile project(':java')
 
     testCompile 'junit:junit:4.12'
+    testCompile 'org.mockito:mockito-core:1.10.19'
 }
 
 publish {

--- a/android/src/main/java/com/novoda/notils/orientation/DebugScreenOrientationLocker.java
+++ b/android/src/main/java/com/novoda/notils/orientation/DebugScreenOrientationLocker.java
@@ -1,0 +1,11 @@
+package com.novoda.notils.orientation;
+
+import android.app.Activity;
+
+class DebugScreenOrientationLocker implements ScreenOrientationLocker {
+
+    @Override
+    public void lockOnFormFactor(Activity activity) {
+        // no-op
+    }
+}

--- a/android/src/main/java/com/novoda/notils/orientation/OrientationLockedActivity.java
+++ b/android/src/main/java/com/novoda/notils/orientation/OrientationLockedActivity.java
@@ -1,0 +1,22 @@
+package com.novoda.notils.orientation;
+
+import android.os.Bundle;
+import android.support.annotation.CallSuper;
+import android.support.v7.app.AppCompatActivity;
+
+/**
+ * Will lock the orientation of your Activity depending on form factor & if in debug mode.
+ * See {@link ScreenOrientationLockerFactory} for more details.
+ */
+public abstract class OrientationLockedActivity extends AppCompatActivity {
+
+    @Override
+    @CallSuper
+    protected void onCreate(Bundle savedInstanceState) {
+        ScreenOrientationLockerFactory.newInstance(getResources())
+                .create()
+                .lockOnFormFactor(this);
+
+        super.onCreate(savedInstanceState);
+    }
+}

--- a/android/src/main/java/com/novoda/notils/orientation/PhoneScreenOrientationLocker.java
+++ b/android/src/main/java/com/novoda/notils/orientation/PhoneScreenOrientationLocker.java
@@ -1,0 +1,18 @@
+package com.novoda.notils.orientation;
+
+import android.app.Activity;
+import android.content.pm.ActivityInfo;
+
+class PhoneScreenOrientationLocker implements ScreenOrientationLocker {
+
+    @Override
+    public void lockOnFormFactor(Activity activity) {
+        if (orientationNotAlreadySpecified(activity)) {
+            activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT);
+        }
+    }
+
+    private boolean orientationNotAlreadySpecified(Activity activity) {
+        return activity.getRequestedOrientation() == ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED;
+    }
+}

--- a/android/src/main/java/com/novoda/notils/orientation/ScreenOrientationLocker.java
+++ b/android/src/main/java/com/novoda/notils/orientation/ScreenOrientationLocker.java
@@ -1,0 +1,12 @@
+package com.novoda.notils.orientation;
+
+import android.app.Activity;
+
+/**
+ * See {@link ScreenOrientationLockerFactory} for useage
+ */
+public interface ScreenOrientationLocker {
+
+    void lockOnFormFactor(Activity activity);
+
+}

--- a/android/src/main/java/com/novoda/notils/orientation/ScreenOrientationLockerFactory.java
+++ b/android/src/main/java/com/novoda/notils/orientation/ScreenOrientationLockerFactory.java
@@ -1,0 +1,44 @@
+package com.novoda.notils.orientation;
+
+import android.content.res.Resources;
+
+import com.novoda.android.BuildConfig;
+import com.novoda.android.R;
+
+/**
+ * This factory can be used to instantiate a {@link ScreenOrientationLocker}
+ * alternatively the {@link OrientationLockedActivity} can be extended for the same behaviour
+ */
+public class ScreenOrientationLockerFactory {
+
+    private final boolean isDebug;
+    private final boolean isTablet;
+
+    public static ScreenOrientationLockerFactory newInstance(Resources resources) {
+        boolean isDebug = BuildConfig.DEBUG;
+        boolean isTablet = resources.getBoolean(R.bool.is_tablet);
+
+        return new ScreenOrientationLockerFactory(isDebug, isTablet);
+    }
+
+    ScreenOrientationLockerFactory(boolean isDebug, boolean isTablet) {
+        this.isDebug = isDebug;
+        this.isTablet = isTablet;
+    }
+
+    /**
+     * @return a {@link ScreenOrientationLocker} that will
+     * lock a phone to portrait when not debugging and lock a tablet to landscape
+     */
+    public ScreenOrientationLocker create() {
+        if (isDebug) {
+            return new DebugScreenOrientationLocker();
+        }
+
+        if (isTablet) {
+            return new TabletScreenOrientationLocker();
+        } else {
+            return new PhoneScreenOrientationLocker();
+        }
+    }
+}

--- a/android/src/main/java/com/novoda/notils/orientation/TabletScreenOrientationLocker.java
+++ b/android/src/main/java/com/novoda/notils/orientation/TabletScreenOrientationLocker.java
@@ -1,0 +1,12 @@
+package com.novoda.notils.orientation;
+
+import android.app.Activity;
+import android.content.pm.ActivityInfo;
+
+class TabletScreenOrientationLocker implements ScreenOrientationLocker {
+
+    @Override
+    public void lockOnFormFactor(Activity activity) {
+        activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
+    }
+}

--- a/android/src/main/res/values-sw600dp/global_booleans.xml
+++ b/android/src/main/res/values-sw600dp/global_booleans.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <bool name="is_tablet">true</bool>
+</resources>

--- a/android/src/main/res/values/global_booleans.xml
+++ b/android/src/main/res/values/global_booleans.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <bool name="is_tablet">false</bool>
+</resources>

--- a/android/src/test/java/com/novoda/notils/orientation/ScreenOrientationLockerTest.java
+++ b/android/src/test/java/com/novoda/notils/orientation/ScreenOrientationLockerTest.java
@@ -1,0 +1,83 @@
+package com.novoda.notils.orientation;
+
+import android.app.Activity;
+import android.content.pm.ActivityInfo;
+import android.content.res.Resources;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class ScreenOrientationLockerTest {
+
+    @Mock
+    private Resources mockResources;
+    @Mock
+    private Activity mockActivity;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        when(mockActivity.getRequestedOrientation()).thenReturn(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+    }
+
+    @Test
+    public void givenDebugBuildAndTablet_WhenLock_ThenLockDoesNotHappen() {
+        boolean isDebug = true;
+        boolean isTablet = true;
+
+        ScreenOrientationLocker screenOrientationLocker = new ScreenOrientationLockerFactory(isDebug, isTablet).create();
+        screenOrientationLocker.lockOnFormFactor(mockActivity);
+
+        verify(mockActivity, never()).setRequestedOrientation(anyInt());
+    }
+
+    @Test
+    public void givenDebugBuildAndPhone_WhenLock_ThenLockDoesNotHappen() {
+        boolean isDebug = true;
+        boolean isTablet = false;
+
+        ScreenOrientationLocker screenOrientationLocker = new ScreenOrientationLockerFactory(isDebug, isTablet).create();
+        screenOrientationLocker.lockOnFormFactor(mockActivity);
+
+        verify(mockActivity, never()).setRequestedOrientation(anyInt());
+    }
+
+    @Test
+    public void givenNoDebugBuildAndPhone_WhenLock_ThenScreenIsLockedToPortrait() {
+        boolean isDebug = false;
+        boolean isTablet = false;
+
+        ScreenOrientationLocker screenOrientationLocker = new ScreenOrientationLockerFactory(isDebug, isTablet).create();
+        screenOrientationLocker.lockOnFormFactor(mockActivity);
+
+        verify(mockActivity).setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT);
+    }
+
+    @Test
+    public void givenNoDebugBuildAndPhoneAndAlreadyLockedToLandscape_WhenLock_ThenScreenIsNotLockedToPortrait() {
+        boolean isDebug = false;
+        boolean isTablet = false;
+        when(mockActivity.getRequestedOrientation()).thenReturn(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+
+        ScreenOrientationLocker screenOrientationLocker = new ScreenOrientationLockerFactory(isDebug, isTablet).create();
+        screenOrientationLocker.lockOnFormFactor(mockActivity);
+
+        verify(mockActivity, never()).setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT);
+    }
+
+    @Test
+    public void givenNoDebugBuildAndTablet_WhenLock_ThenScreenIsLockedToLandscape() {
+        boolean isDebug = false;
+        boolean isTablet = true;
+
+        ScreenOrientationLocker screenOrientationLocker = new ScreenOrientationLockerFactory(isDebug, isTablet).create();
+        screenOrientationLocker.lockOnFormFactor(mockActivity);
+
+        verify(mockActivity).setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
+    }
+}


### PR DESCRIPTION
Allows some to use the `ScreenOrientationLockerFactory` to create a screen orientation locker, or `extend OrientationLockedActivity`.

https://www.novoda.com/blog/portrait-only-apps/

This assumes you want Phones locked to portrait and tablets locked to landscape. Future changes could make this configurable I guess.

Sidenote:
   Yes there are other ways to do this with resource buckets and we could _also_ add that method for orientation locking. Doing it programmatically I feel makes it more explicit but that doesn't matter anyway for this PR, as in the end NoTils could have both choices until one id decided better.