### PR TITLE
Add ctor with timezone argument and tests for it

### DIFF
--- a/java/src/main/java/com/novoda/notils/date/SimpleDateFormatThreadSafe.java
+++ b/java/src/main/java/com/novoda/notils/date/SimpleDateFormatThreadSafe.java
@@ -30,11 +30,25 @@ public class SimpleDateFormatThreadSafe {
         this(new SimpleDateFormat(pattern, locale));
     }
 
+    public SimpleDateFormatThreadSafe(final String pattern, final TimeZone timeZone) {
+        this(new SimpleDateFormat(pattern), timeZone);
+    }
+
     public SimpleDateFormatThreadSafe(final SimpleDateFormat localSimpleDateFormat) {
         this.localSimpleDateFormat = new ThreadLocal<SimpleDateFormat>() {
             @Override
             protected SimpleDateFormat initialValue() {
                 return localSimpleDateFormat;
+            }
+        };
+    }
+
+    public SimpleDateFormatThreadSafe(final SimpleDateFormat simpleDateFormat, final TimeZone timeZone) {
+        this.localSimpleDateFormat = new ThreadLocal<SimpleDateFormat>() {
+            @Override
+            protected SimpleDateFormat initialValue() {
+                simpleDateFormat.setTimeZone(timeZone);
+                return simpleDateFormat;
             }
         };
     }

--- a/java/src/test/java/com/novoda/notils/date/SimpleDateFormatThreadSafeTest.java
+++ b/java/src/test/java/com/novoda/notils/date/SimpleDateFormatThreadSafeTest.java
@@ -1,0 +1,119 @@
+package com.novoda.notils.date;
+
+import org.junit.Test;
+
+import java.text.ParseException;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+
+public class SimpleDateFormatThreadSafeTest {
+    String DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+
+    @Test
+    public void givenStringDateInISOFormat_WhenTimeZoneIsUTC_ThenUTCTimeIsTheSame() {
+        SimpleDateFormatThreadSafe formatter = givenFormatterForTimeZone(timeZoneUTC());
+        
+        Date date = parseTestDate("2016-01-01T10:00:00Z", formatter);
+
+        assertEquals(date, createUTCDate(2016, Calendar.JANUARY, 1, 10));
+    }
+
+    @Test
+    public void givenStringDateInISOFormat_WhenTimeZoneIsUTC_ThenUTCPlusOneTimeIsOneHourMore() {
+        // This test exercises British Summer Time (device) vs UTC (API)
+        SimpleDateFormatThreadSafe formatter = givenFormatterForTimeZone(timeZoneUTC());
+
+        Date date = parseTestDate("2016-01-01T10:00:00Z", formatter);
+
+        assertEquals(date, createDate(2016, Calendar.JANUARY, 1, 11, timeZoneUTCPlusOne()));
+    }
+
+    @Test
+    public void givenStringDateInISOFormat_WhenTimeZoneIsUTCPlusOne_ThenUTCTimeIsOneHourLess() {
+        SimpleDateFormatThreadSafe formatter = givenFormatterForTimeZone(timeZoneUTCPlusOne());
+        
+        Date date = parseTestDate("2016-01-01T10:00:00Z", formatter);
+
+        assertEquals(date, createUTCDate(2016, Calendar.JANUARY, 1, 9));
+    }
+
+    @Test
+    public void givenStringDateInISOFormat_WhenTimeZoneIsUTCPlusTwo_ThenUTCTimeIsTwoHoursLess() {
+        SimpleDateFormatThreadSafe formatter = givenFormatterForTimeZone(timeZoneUTCPlusTwo());
+        
+        Date date = parseTestDate("2016-01-01T10:00:00Z", formatter);
+
+        assertEquals(date, createUTCDate(2016, Calendar.JANUARY, 1, 8));
+    }
+
+    @Test
+    public void givenStringDateInISOFormat_WhenTimeZoneIsUTCMinusOne_ThenUTCTimeIsOneHourMore() {
+        SimpleDateFormatThreadSafe formatter = givenFormatterForTimeZone(timeZoneUTCMinusOne());
+        
+        Date date = parseTestDate("2016-01-01T10:00:00Z", formatter);
+
+        assertEquals(date, createUTCDate(2016, Calendar.JANUARY, 1, 11));
+    }
+
+    @Test
+    public void givenStringDateInISOFormat_WhenTimeZoneIsPST_ThenUTCTimeIsSevenHoursLess() {
+        SimpleDateFormatThreadSafe formatter = givenFormatterForTimeZone(timeZonePST());
+
+        Date date = parseTestDate("2016-01-01T10:00:00Z", formatter);
+
+        assertEquals(date, createUTCDate(2016, Calendar.JANUARY, 1, 18));
+    }
+
+    private SimpleDateFormatThreadSafe givenFormatterForTimeZone(TimeZone timeZoneUTC) {
+        return new SimpleDateFormatThreadSafe(DATE_PATTERN, timeZoneUTC);
+    }
+
+    private Date parseTestDate(String dateString, SimpleDateFormatThreadSafe formatter) {
+        Date date = null;
+        try {
+            date = formatter.parse(dateString);
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+        return date;
+    }
+
+    private Date createUTCDate(int year, int month, int date, int hour) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(year, month, date, hour, 0, 0);
+        calendar.set(Calendar.MILLISECOND, 0);
+        calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return calendar.getTime();
+    }
+
+    private Date createDate(int year, int month, int date, int hour, TimeZone timeZone) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(year, month, date, hour, 0, 0);
+        calendar.set(Calendar.MILLISECOND, 0);
+        calendar.setTimeZone(timeZone);
+        return calendar.getTime();
+    }
+
+    private TimeZone timeZoneUTC() {
+        return TimeZone.getTimeZone("GMT");
+    }
+
+    private TimeZone timeZoneUTCPlusOne() {
+        return TimeZone.getTimeZone("GMT+1");
+    }
+
+    private TimeZone timeZoneUTCPlusTwo() {
+        return TimeZone.getTimeZone("GMT+2");
+    }
+
+    private TimeZone timeZoneUTCMinusOne() {
+        return TimeZone.getTimeZone("GMT-1");
+    }
+
+    private TimeZone timeZonePST() {
+        return TimeZone.getTimeZone("PST");
+    }
+}

--- a/java/src/test/java/com/novoda/notils/date/SimpleDateFormatThreadSafeTest.java
+++ b/java/src/test/java/com/novoda/notils/date/SimpleDateFormatThreadSafeTest.java
@@ -1,11 +1,11 @@
 package com.novoda.notils.date;
 
-import org.junit.Test;
-
 import java.text.ParseException;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
+
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
@@ -23,7 +23,7 @@ public class SimpleDateFormatThreadSafeTest {
 
     @Test
     public void givenStringDateInISOFormat_WhenTimeZoneIsUTC_ThenUTCPlusOneTimeIsOneHourMore() {
-        // This test exercises British Summer Time (device) vs UTC (API)
+        // This test exercises UTC (API) vs British Summer Time (UTC + 1)
         SimpleDateFormatThreadSafe formatter = givenFormatterForTimeZone(timeZoneUTC());
 
         Date date = parseTestDate("2016-01-01T10:00:00Z", formatter);


### PR DESCRIPTION
This PR adds a constructor to `SimpleDateFormatThreadSafe` that takes a string pattern and a timezone. 
It will parse the string representation according to defined timezone.

_Bonus points:_ Some tests for this behaviour!

_TODO_:
- There is a lack of unit tests for the rest of this class functionality
- Builder pattern anyone?