### PR TITLE
DeveloperError is a final class

### DIFF
--- a/java/src/main/java/com/novoda/notils/exception/DeveloperError.java
+++ b/java/src/main/java/com/novoda/notils/exception/DeveloperError.java
@@ -6,7 +6,7 @@ package com.novoda.notils.exception;
  * get feedback on the situation.
  * <b>You should never try catch a DeveloperError</b>
  */
-public class DeveloperError extends Error {
+public final class DeveloperError extends Error {
 
     public DeveloperError(String detailMessage) {
         super(detailMessage);


### PR DESCRIPTION
As title says.... DeveloperError is now a final class. Based on this issue https://github.com/novoda/notils/issues/51