### PR TITLE
Cut down the notils-android AndroidManifest.xml

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,11 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.novoda.android">
-
-    <application android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true"
->
-
-    </application>
-
-</manifest>
+<manifest package="com.novoda.android" />


### PR DESCRIPTION
When integrating `notils-android` into one of our projects, gradle sync was failing due to manifest merger errors.

This was because both the project in question and `notils-android` were defining the `android:supportsRtl` directive in their manifests' `application` tags.

Due to a bug detailed here - https://code.google.com/p/android/issues/detail?id=193679 - there is no way to specify which `supportsRtl` directive should be replaced.

So in order to combat this, I removed as much of `notils-android`'s manifest as I could. It's not actually an application anyway, so this should be fine.

I tested this after cutting down the manifest by rebuilding the .aar file locally and adding that into one of our projects. Everything worked fine, there was no problem with gradle sync or running tests or the app itself.