### PR TITLE
Extract dependencies to separate gradle file

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath librariesBuild.androidGradleBuildTools
+        classpath libraries.build.androidGradle
     }
 }
 
@@ -32,10 +32,10 @@ android {
 }
 
 dependencies {
-    compile libraries.supportAppCompatV7
+    compile libraries.app.supportAppCompatV7
     compile project(':java')
 
-    testCompile librariesTest.jUnit
+    testCompile libraries.test.jUnit
 }
 
 publish {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,7 +20,6 @@ android {
 
     defaultConfig {
         minSdkVersion versions.androidSdk.min
-        targetSdkVersion versions.androidSdk.target
         versionCode 1
         versionName "1.0"
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath librariesBuild.androidGradleBuildTools
     }
 }
 
@@ -15,12 +15,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'bintray-release'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion androidCompileSdkVersion
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 23
+        minSdkVersion androidMinSdkVersion
+        targetSdkVersion androidTargetSdkVersion
         versionCode 1
         versionName "1.0"
     }
@@ -33,10 +33,10 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:23.1.1'
+    compile libraries.supportAppCompatV7
     compile project(':java')
 
-    testCompile 'junit:junit:4.12'
+    testCompile librariesTest.jUnit
 }
 
 publish {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,12 +15,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'bintray-release'
 
 android {
-    compileSdkVersion androidCompileSdkVersion
-    buildToolsVersion androidBuildToolsVersion
+    compileSdkVersion versions.androidSdk.compile
+    buildToolsVersion versions.androidSdk.buildTools
 
     defaultConfig {
-        minSdkVersion androidMinSdkVersion
-        targetSdkVersion androidTargetSdkVersion
+        minSdkVersion versions.androidSdk.min
+        targetSdkVersion versions.androidSdk.target
         versionCode 1
         versionName "1.0"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,12 @@
 buildscript {
+    apply from: 'dependencies.gradle'
     repositories {
         jcenter()
     }
     dependencies {
-        classpath 'com.novoda:bintray-release:0.2.4'
+        classpath libraries.build.bintrayRelease
     }
 }
-
-apply from: 'dependencies.gradle'
 
 allprojects {
     version = "3.0.2"

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,8 @@ buildscript {
     }
 }
 
+apply from: 'dependencies.gradle'
+
 allprojects {
     version = "3.0.0"
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -10,15 +10,16 @@ ext {
         ]
     ]
 
-    librariesBuild = [
-        androidGradleBuildTools: 'com.android.tools.build:gradle:1.2.3'
-    ]
-
     libraries = [
-        supportAppCompatV7: "com.android.support:appcompat-v7:${versions.support}"
-    ]
-
-    librariesTest = [
-        jUnit: 'junit:junit:4.12'
+        build: [
+            androidGradle : 'com.android.tools.build:gradle:1.2.3',
+            bintrayRelease: 'com.novoda:bintray-release:0.2.4'
+        ],
+        app: [
+            supportAppCompatV7: "com.android.support:appcompat-v7:${versions.support}"
+        ],
+        test: [
+            jUnit: 'junit:junit:4.12'
+        ]
     ]
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,0 +1,20 @@
+ext {
+    androidCompileSdkVersion = 23
+    androidBuildToolsVersion = '23.0.2'
+    androidMinSdkVersion = 14
+    androidTargetSdkVersion = 23 // should we be specifying this?
+
+    supportLibraryVersion = '23.1.1'
+
+    librariesBuild = [
+        androidGradleBuildTools: 'com.android.tools.build:gradle:1.2.3'
+    ]
+
+    libraries = [
+        supportAppCompatV7: "com.android.support:appcompat-v7:${supportLibraryVersion}"
+    ]
+
+    librariesTest = [
+        jUnit: 'junit:junit:4.12'
+    ]
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,7 +6,6 @@ ext {
         androidSdk         : [
             compile   : 23,
             min       : 14,
-            target    : 23,
             buildTools: '23.0.2'
         ]
     ]

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,17 +1,22 @@
 ext {
-    androidCompileSdkVersion = 23
-    androidBuildToolsVersion = '23.0.2'
-    androidMinSdkVersion = 14
-    androidTargetSdkVersion = 23 // should we be specifying this?
-
-    supportLibraryVersion = '23.1.1'
+    versions = [
+        sourceCompatibility: JavaVersion.VERSION_1_7,
+        targetCompatibility: JavaVersion.VERSION_1_7,
+        support            : '23.1.1',
+        androidSdk         : [
+            compile   : 23,
+            min       : 14,
+            target    : 23,
+            buildTools: '23.0.2'
+        ]
+    ]
 
     librariesBuild = [
         androidGradleBuildTools: 'com.android.tools.build:gradle:1.2.3'
     ]
 
     libraries = [
-        supportAppCompatV7: "com.android.support:appcompat-v7:${supportLibraryVersion}"
+        supportAppCompatV7: "com.android.support:appcompat-v7:${versions.support}"
     ]
 
     librariesTest = [

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -5,8 +5,8 @@ repositories {
 apply plugin: 'java'
 apply plugin: 'bintray-release'
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = versions.sourceCompatibility
+targetCompatibility = versions.targetCompatibility
 
 dependencies {
     testCompile librariesTest.jUnit

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -9,7 +9,7 @@ sourceCompatibility = versions.sourceCompatibility
 targetCompatibility = versions.targetCompatibility
 
 dependencies {
-    testCompile librariesTest.jUnit
+    testCompile libraries.test.jUnit
 }
 
 publish {

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'java'
 apply plugin: 'bintray-release'
 
 dependencies {
-    testCompile 'junit:junit:4.12'
+    testCompile librariesTest.jUnit
 }
 
 publish {

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -5,10 +5,11 @@ repositories {
 apply plugin: 'java'
 apply plugin: 'bintray-release'
 
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
 dependencies {
     testCompile librariesTest.jUnit
-    sourceCompatibility = 1.7
-    targetCompatibility = 1.7
 }
 
 publish {


### PR DESCRIPTION
Pulls out all the hardcoded versions/dependencies.

This will make it easier to:

- reference dependencies in various modules
- update a version in one place, and have it synced for all places

I didn't update any versions in this PR.

I added a note onto the `targetSdkVersion` - I thought I saw something from @tasomaniac that suggests we shouldn't include this in libraries, but can't remember. This can be amended in this PR.