### PR TITLE
Update dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
     }
 }
 
@@ -15,12 +15,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'bintray-release'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 23
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }
@@ -33,7 +33,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:23.1.1'
+    compile 'com.android.support:appcompat-v7:25.2.0'
     compile project(':java')
 
     testCompile 'junit:junit:4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.novoda:bintray-release:0.2.4'
+        classpath 'com.novoda:bintray-release:0.4.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Aug 09 11:54:01 CEST 2016
+#Tue Mar 07 15:22:10 GMT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
### Description

This Pull Request updates the dependencies:
- gradle tools from v1.2.3 -> v2.3.0 [changelog](https://developer.android.com/studio/releases/gradle-plugin.html#)
- gradle from v2.2 -> v3.3 [changelog](https://docs.gradle.org/3.3/release-notes.html)
- android build tools from 23.0.2 -> 25.0.2 [changelog](https://developer.android.com/studio/releases/build-tools.html#)
- compile sdk version from 23 -> 25
- appcompat-v7 from 23.1.1 -> 25.2.0 [changelog](https://developer.android.com/topic/libraries/support-library/revisions.html)
- novoda bintray v0.2.4 -> 0.4.0 [changelog](https://github.com/novoda/bintray-release/releases/tag/0.4.0)