### PR TITLE
Add 16 JellyBean to AndroidVersion

### DIFF
--- a/android/src/main/java/com/novoda/notils/devicedetection/AndroidVersion.java
+++ b/android/src/main/java/com/novoda/notils/devicedetection/AndroidVersion.java
@@ -16,6 +16,14 @@ public class AndroidVersion {
         this.osVersionName = osVersionName;
     }
 
+    public boolean is16JellyBean() {
+        return osApiLevel == Build.VERSION_CODES.JELLY_BEAN;
+    }
+
+    public boolean is16JellyBeanOrOver() {
+        return osApiLevel >= Build.VERSION_CODES.JELLY_BEAN;
+    }
+
     public boolean is18JellyBeanOrOver() {
         return osApiLevel >= Build.VERSION_CODES.JELLY_BEAN_MR2;
     }


### PR DESCRIPTION
Updating one of the projects, I realized that we don't have JellyBean 16 here. For completeness, adding that too. After this, will have another update.
